### PR TITLE
Use newest patches for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-package-lock.json
 .DS_Store
+node_modules/

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
         "url": "https://github.com/BlackrockDigital/startbootstrap-grayscale.git"
     },
     "dependencies": {
-        "bootstrap": "4.1.1",
-        "font-awesome": "4.7.0",
-        "jquery": "3.3.1",
+        "bootstrap": "4.1.x",
+        "font-awesome": "4.7.x",
+        "jquery": "3.3.x",
         "jquery.easing": "^1.4.1"
     },
     "devDependencies": {


### PR DESCRIPTION
This should help with security vulnerabilities in the deps. I think you may have to rebuild package-lock.json with gulp and push that, but I didn't have any build instructions in the README so I didn't figure it out myself. If the site is still down it could be for other reasons