### PR TITLE
Fix security vulnerabilities with updated 2 packages in 3.603s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,30 @@
             "dev": true
         },
         "accepts": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-            "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+            "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
             "dev": true,
             "requires": {
-                "mime-types": "~2.1.18",
-                "negotiator": "0.6.1"
+                "mime-types": "~2.1.24",
+                "negotiator": "0.6.2"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.40.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+                    "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.24",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+                    "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.40.0"
+                    }
+                }
             }
         },
         "after": {
@@ -79,13 +96,24 @@
             "dev": true
         },
         "anymatch": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-            "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+            "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "^2.1.5",
-                "normalize-path": "^2.0.0"
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
+            },
+            "dependencies": {
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                }
             }
         },
         "aproba": {
@@ -111,13 +139,10 @@
             }
         },
         "arr-diff": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-            "dev": true,
-            "requires": {
-                "arr-flatten": "^1.0.1"
-            }
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+            "dev": true
         },
         "arr-flatten": {
             "version": "1.1.0",
@@ -162,9 +187,9 @@
             "dev": true
         },
         "array-unique": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
             "dev": true
         },
         "arraybuffer.slice": {
@@ -198,9 +223,9 @@
             "dev": true
         },
         "async-each": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
             "dev": true
         },
         "async-each-series": {
@@ -216,9 +241,9 @@
             "dev": true
         },
         "async-limiter": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-            "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
             "dev": true
         },
         "asynckit": {
@@ -246,13 +271,21 @@
             "dev": true
         },
         "axios": {
-            "version": "0.17.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+            "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
             "dev": true,
             "requires": {
-                "follow-redirects": "^1.2.5",
-                "is-buffer": "^1.1.5"
+                "follow-redirects": "1.5.10",
+                "is-buffer": "^2.0.2"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+                    "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+                    "dev": true
+                }
             }
         },
         "backo2": {
@@ -378,15 +411,15 @@
             }
         },
         "binary-extensions": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-            "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
             "dev": true
         },
         "blob": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-            "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+            "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
             "dev": true
         },
         "block-stream": {
@@ -416,9 +449,9 @@
             }
         },
         "bootstrap": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
-            "integrity": "sha1-DrNxryyESOjCEEEdDLgkpkCaEr4="
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+            "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -431,43 +464,64 @@
             }
         },
         "braces": {
-            "version": "1.8.5",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "browser-sync": {
-            "version": "2.24.6",
-            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.6.tgz",
-            "integrity": "sha512-3cVW8Ft3sPQ1t9gqZXBDZhTyRce8NW4wf5KzpCYcg6fWjPbyt+vZLvEo+sTq7c7eNQhi8lInQWbjIFEpoM2f7Q==",
+            "version": "2.26.7",
+            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.7.tgz",
+            "integrity": "sha512-lY3emme0OyvA2ujEMpRmyRy9LY6gHLuTr2/ABxhIm3lADOiRXzP4dgekvnDrQqZ/Ec2Fz19lEjm6kglSG5766w==",
             "dev": true,
             "requires": {
-                "browser-sync-ui": "v1.0.1",
+                "browser-sync-client": "^2.26.6",
+                "browser-sync-ui": "^2.26.4",
                 "bs-recipes": "1.3.4",
-                "chokidar": "1.7.0",
+                "bs-snippet-injector": "^2.0.1",
+                "chokidar": "^2.0.4",
                 "connect": "3.6.6",
-                "connect-history-api-fallback": "^1.5.0",
+                "connect-history-api-fallback": "^1",
                 "dev-ip": "^1.0.1",
-                "easy-extender": "2.3.2",
-                "eazy-logger": "3.0.2",
+                "easy-extender": "^2.3.4",
+                "eazy-logger": "^3",
                 "etag": "^1.8.1",
                 "fresh": "^0.5.2",
                 "fs-extra": "3.0.1",
                 "http-proxy": "1.15.2",
-                "immutable": "3.8.2",
-                "localtunnel": "1.9.0",
-                "micromatch": "2.3.11",
-                "opn": "4.0.2",
+                "immutable": "^3",
+                "localtunnel": "1.9.2",
+                "micromatch": "^3.1.10",
+                "opn": "5.3.0",
                 "portscanner": "2.1.1",
                 "qs": "6.2.3",
                 "raw-body": "^2.3.2",
                 "resp-modifier": "6.0.2",
                 "rx": "4.1.0",
+                "send": "0.16.2",
                 "serve-index": "1.9.1",
                 "serve-static": "1.13.2",
                 "server-destroy": "1.0.1",
@@ -476,17 +530,29 @@
                 "yargs": "6.4.0"
             }
         },
+        "browser-sync-client": {
+            "version": "2.26.6",
+            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.6.tgz",
+            "integrity": "sha512-mGrkZdNzttKdf/16I+y+2dTQxoMCIpKbVIMJ/uP8ZpnKu9f9qa/2CYVtLtbjZG8nsM14EwiCrjuFTGBEnT3Gjw==",
+            "dev": true,
+            "requires": {
+                "etag": "1.8.1",
+                "fresh": "0.5.2",
+                "mitt": "^1.1.3",
+                "rxjs": "^5.5.6"
+            }
+        },
         "browser-sync-ui": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-1.0.1.tgz",
-            "integrity": "sha1-l0BSeybR16ziWazAx55bXjfQ/fI=",
+            "version": "2.26.4",
+            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.4.tgz",
+            "integrity": "sha512-u20P3EsZoM8Pt+puoi3BU3KlbQAH1lAcV+/O4saF26qokrBqIDotmGonfWwoRbUmdxZkM9MBmA0K39ZTG1h4sA==",
             "dev": true,
             "requires": {
                 "async-each-series": "0.1.1",
-                "connect-history-api-fallback": "^1.1.0",
-                "immutable": "^3.7.6",
+                "connect-history-api-fallback": "^1",
+                "immutable": "^3",
                 "server-destroy": "1.0.1",
-                "socket.io-client": "2.0.4",
+                "socket.io-client": "^2.0.4",
                 "stream-throttle": "^0.1.3"
             }
         },
@@ -496,6 +562,12 @@
             "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
             "dev": true
         },
+        "bs-snippet-injector": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/bs-snippet-injector/-/bs-snippet-injector-2.0.1.tgz",
+            "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
+            "dev": true
+        },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -503,9 +575,9 @@
             "dev": true
         },
         "bytes": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+            "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
             "dev": true
         },
         "cache-base": {
@@ -583,20 +655,23 @@
             }
         },
         "chokidar": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-            "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+            "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
             "dev": true,
             "requires": {
-                "anymatch": "^1.3.0",
-                "async-each": "^1.0.0",
-                "fsevents": "^1.0.0",
-                "glob-parent": "^2.0.0",
-                "inherits": "^2.0.1",
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.1",
+                "braces": "^2.3.2",
+                "fsevents": "^1.2.7",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
-                "is-glob": "^2.0.0",
+                "is-glob": "^4.0.0",
+                "normalize-path": "^3.0.0",
                 "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0"
+                "readdirp": "^2.2.1",
+                "upath": "^1.1.1"
             }
         },
         "class-utils": {
@@ -772,9 +847,9 @@
             }
         },
         "connect-history-api-fallback": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-            "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+            "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
             "dev": true
         },
         "console-control-strings": {
@@ -1025,12 +1100,12 @@
             }
         },
         "easy-extender": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
-            "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
+            "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
             "dev": true,
             "requires": {
-                "lodash": "^3.10.1"
+                "lodash": "^4.17.10"
             }
         },
         "eazy-logger": {
@@ -1075,9 +1150,9 @@
             }
         },
         "engine.io": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
-            "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
+            "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.4",
@@ -1096,13 +1171,24 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
+                },
+                "ws": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+                    "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+                    "dev": true,
+                    "requires": {
+                        "async-limiter": "~1.0.0",
+                        "safe-buffer": "~5.1.0",
+                        "ultron": "~1.1.0"
+                    }
                 }
             }
         },
         "engine.io-client": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
-            "integrity": "sha1-W96xMPi5SlCsXL63JYPnpKBj3f0=",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
+            "integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
             "dev": true,
             "requires": {
                 "component-emitter": "1.2.1",
@@ -1113,7 +1199,7 @@
                 "indexof": "0.0.1",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "ws": "~3.3.1",
+                "ws": "~6.1.0",
                 "xmlhttprequest-ssl": "~1.5.4",
                 "yeast": "0.1.2"
             },
@@ -1130,15 +1216,15 @@
             }
         },
         "engine.io-parser": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-            "integrity": "sha1-TA9M/3mq7su9z96maoI8YIVAkZY=",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+            "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
             "dev": true,
             "requires": {
                 "after": "0.8.2",
                 "arraybuffer.slice": "~0.0.7",
                 "base64-arraybuffer": "0.1.5",
-                "blob": "0.0.4",
+                "blob": "0.0.5",
                 "has-binary2": "~1.0.2"
             }
         },
@@ -1176,21 +1262,38 @@
             "dev": true
         },
         "expand-brackets": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "^0.1.0"
-            }
-        },
-        "expand-range": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true,
-            "requires": {
-                "fill-range": "^2.1.0"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "expand-tilde": {
@@ -1230,12 +1333,74 @@
             }
         },
         "extglob": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+            "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "is-extglob": "^1.0.0"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
             }
         },
         "extsprintf": {
@@ -1267,23 +1432,27 @@
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
             "dev": true
         },
-        "filename-regex": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-            "dev": true
-        },
         "fill-range": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-            "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "is-number": "^2.1.0",
-                "isobject": "^2.0.0",
-                "randomatic": "^3.0.0",
-                "repeat-element": "^1.1.2",
-                "repeat-string": "^1.5.2"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "finalhandler": {
@@ -1646,12 +1815,12 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
-            "integrity": "sha1-Z6jxT1ofZ/liwsRkaceersCpApE=",
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
             "dev": true,
             "requires": {
-                "debug": "^3.1.0"
+                "debug": "=3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -1675,15 +1844,6 @@
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
-        },
-        "for-own": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "dev": true,
-            "requires": {
-                "for-in": "^1.0.1"
-            }
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -1735,14 +1895,14 @@
             "dev": true
         },
         "fsevents": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-            "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+            "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.10.0"
+                "nan": "^2.12.1",
+                "node-pre-gyp": "^0.12.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -1763,7 +1923,7 @@
                     "optional": true
                 },
                 "are-we-there-yet": {
-                    "version": "1.1.4",
+                    "version": "1.1.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -1787,7 +1947,7 @@
                     }
                 },
                 "chownr": {
-                    "version": "1.0.1",
+                    "version": "1.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -1814,16 +1974,16 @@
                     "optional": true
                 },
                 "debug": {
-                    "version": "2.6.9",
+                    "version": "4.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
                 },
                 "deep-extend": {
-                    "version": "0.5.1",
+                    "version": "0.6.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -1872,7 +2032,7 @@
                     }
                 },
                 "glob": {
-                    "version": "7.1.2",
+                    "version": "7.1.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -1892,12 +2052,12 @@
                     "optional": true
                 },
                 "iconv-lite": {
-                    "version": "0.4.21",
+                    "version": "0.4.24",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "^2.1.0"
+                        "safer-buffer": ">= 2.1.2 < 3"
                     }
                 },
                 "ignore-walk": {
@@ -1958,16 +2118,16 @@
                     "dev": true
                 },
                 "minipass": {
-                    "version": "2.2.4",
+                    "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "^5.1.1",
+                        "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
-                    "version": "1.1.0",
+                    "version": "1.2.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -1984,35 +2144,42 @@
                     }
                 },
                 "ms": {
-                    "version": "2.0.0",
+                    "version": "2.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
+                "nan": {
+                    "version": "2.14.0",
+                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+                    "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+                    "dev": true,
+                    "optional": true
+                },
                 "needle": {
-                    "version": "2.2.0",
+                    "version": "2.3.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "^2.1.2",
+                        "debug": "^4.1.0",
                         "iconv-lite": "^0.4.4",
                         "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
-                    "version": "0.10.0",
+                    "version": "0.12.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
                         "detect-libc": "^1.0.2",
                         "mkdirp": "^0.5.1",
-                        "needle": "^2.2.0",
+                        "needle": "^2.2.1",
                         "nopt": "^4.0.1",
                         "npm-packlist": "^1.1.6",
                         "npmlog": "^4.0.2",
-                        "rc": "^1.1.7",
+                        "rc": "^1.2.7",
                         "rimraf": "^2.6.1",
                         "semver": "^5.3.0",
                         "tar": "^4"
@@ -2029,13 +2196,13 @@
                     }
                 },
                 "npm-bundled": {
-                    "version": "1.0.3",
+                    "version": "1.0.6",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
-                    "version": "1.1.10",
+                    "version": "1.4.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2110,12 +2277,12 @@
                     "optional": true
                 },
                 "rc": {
-                    "version": "1.2.7",
+                    "version": "1.2.8",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "^0.5.1",
+                        "deep-extend": "^0.6.0",
                         "ini": "~1.3.0",
                         "minimist": "^1.2.0",
                         "strip-json-comments": "~2.0.1"
@@ -2145,16 +2312,16 @@
                     }
                 },
                 "rimraf": {
-                    "version": "2.6.2",
+                    "version": "2.6.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "^7.1.3"
                     }
                 },
                 "safe-buffer": {
-                    "version": "5.1.1",
+                    "version": "5.1.2",
                     "bundled": true,
                     "dev": true
                 },
@@ -2171,7 +2338,7 @@
                     "optional": true
                 },
                 "semver": {
-                    "version": "5.5.0",
+                    "version": "5.7.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2222,17 +2389,17 @@
                     "optional": true
                 },
                 "tar": {
-                    "version": "4.4.1",
+                    "version": "4.4.8",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "^1.0.1",
+                        "chownr": "^1.1.1",
                         "fs-minipass": "^1.2.5",
-                        "minipass": "^2.2.4",
-                        "minizlib": "^1.1.0",
+                        "minipass": "^2.3.4",
+                        "minizlib": "^1.1.1",
                         "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.1",
+                        "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.2"
                     }
                 },
@@ -2243,12 +2410,12 @@
                     "optional": true
                 },
                 "wide-align": {
-                    "version": "1.1.2",
+                    "version": "1.1.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "^1.0.2 || 2"
                     }
                 },
                 "wrappy": {
@@ -2257,16 +2424,16 @@
                     "dev": true
                 },
                 "yallist": {
-                    "version": "3.0.2",
+                    "version": "3.0.3",
                     "bundled": true,
                     "dev": true
                 }
             }
         },
         "fstream": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
@@ -2358,23 +2525,25 @@
                 }
             }
         },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true,
-            "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
-            }
-        },
         "glob-parent": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "^2.0.0"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+            },
+            "dependencies": {
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                }
             }
         },
         "glob-stream": {
@@ -2708,9 +2877,9 @@
             },
             "dependencies": {
                 "lodash": {
-                    "version": "4.17.10",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-                    "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
                     "dev": true
                 }
             }
@@ -2920,17 +3089,24 @@
             "dev": true
         },
         "http-errors": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+            "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
             "dev": true,
             "requires": {
                 "depd": "~1.1.2",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
+                "inherits": "2.0.4",
+                "setprototypeof": "1.1.1",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.0"
             },
             "dependencies": {
+                "inherits": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                    "dev": true
+                },
                 "statuses": {
                     "version": "1.5.0",
                     "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -2961,9 +3137,9 @@
             }
         },
         "iconv-lite": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-            "integrity": "sha1-KXhx9jvlB63Pv8pxXQzQ7thOmmM=",
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
@@ -3107,21 +3283,6 @@
                 }
             }
         },
-        "is-dotfile": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-            "dev": true
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
-            "requires": {
-                "is-primitive": "^2.0.0"
-            }
-        },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -3129,9 +3290,9 @@
             "dev": true
         },
         "is-extglob": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "dev": true
         },
         "is-finite": {
@@ -3153,18 +3314,18 @@
             }
         },
         "is-glob": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
             "dev": true,
             "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-number": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
@@ -3195,18 +3356,6 @@
                     "dev": true
                 }
             }
-        },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
         },
         "is-relative": {
             "version": "1.0.0",
@@ -3244,6 +3393,12 @@
             "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
             "dev": true
         },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
+        },
         "isarray": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
@@ -3257,21 +3412,10 @@
             "dev": true
         },
         "isobject": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-            "dev": true,
-            "requires": {
-                "isarray": "1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
-                }
-            }
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "dev": true
         },
         "isstream": {
             "version": "0.1.2",
@@ -3280,9 +3424,9 @@
             "dev": true
         },
         "jquery": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-            "integrity": "sha1-lYzinoHJeQ8xvneS311NlfxX+8o="
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+            "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
         },
         "jquery.easing": {
             "version": "1.4.1",
@@ -3399,9 +3543,9 @@
             }
         },
         "limiter": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.3.tgz",
-            "integrity": "sha1-MuLrVbIyQHaUPl0EwRhf+zh5aO8=",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.4.tgz",
+            "integrity": "sha512-XCpr5bElgDI65vVgstP8TWjv6/QKWm9GU5UG0Pr5sLQ3QLo8NVKsioe+Jed5/3vFOe3IQuqE7DKwTvKQkjTHvg==",
             "dev": true
         },
         "load-json-file": {
@@ -3418,25 +3562,31 @@
             }
         },
         "localtunnel": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
-            "integrity": "sha1-j/7Nz4yKFPYt8QVs+dVKy7C7mo8=",
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.2.tgz",
+            "integrity": "sha512-NEKF7bDJE9U3xzJu3kbayF0WTvng6Pww7tzqNb/XtEARYwqw7CKEX7BvOMg98FtE9es2CRizl61gkV3hS8dqYg==",
             "dev": true,
             "requires": {
-                "axios": "0.17.1",
-                "debug": "2.6.8",
+                "axios": "0.19.0",
+                "debug": "4.1.1",
                 "openurl": "1.1.1",
                 "yargs": "6.6.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.6.8",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
                 },
                 "yargs": {
                     "version": "6.6.0",
@@ -3462,10 +3612,9 @@
             }
         },
         "lodash": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-            "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-            "dev": true
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "lodash._basecopy": {
             "version": "3.0.1",
@@ -3572,9 +3721,9 @@
             }
         },
         "lodash.mergewith": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-            "integrity": "sha1-Y5BX5ybDr72z59QnQcqo1uQzWSc=",
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+            "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
             "dev": true
         },
         "lodash.restparam": {
@@ -3679,12 +3828,6 @@
                 "object-visit": "^1.0.0"
             }
         },
-        "math-random": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-            "dev": true
-        },
         "meow": {
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -3704,24 +3847,32 @@
             }
         },
         "micromatch": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
             }
         },
         "mime": {
@@ -3760,10 +3911,16 @@
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
             "dev": true
         },
+        "mitt": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.1.3.tgz",
+            "integrity": "sha512-mUDCnVNsAi+eD6qA0HkRkwYczbLHJ49z17BGe2PYRhZL4wpZUFZGJHU7/5tmvohoma+Hdn0Vh/oJTiPEmgSruA==",
+            "dev": true
+        },
         "mixin-deep": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-            "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
             "dev": true,
             "requires": {
                 "for-in": "^1.0.2",
@@ -3865,9 +4022,9 @@
             "dev": true
         },
         "negotiator": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+            "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
             "dev": true
         },
         "node-gyp": {
@@ -4011,8 +4168,7 @@
                 },
                 "lodash": {
                     "version": "4.17.10",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-                    "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
+                    "resolved": "",
                     "dev": true
                 }
             }
@@ -4039,13 +4195,10 @@
             }
         },
         "normalize-path": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-            "dev": true,
-            "requires": {
-                "remove-trailing-separator": "^1.0.1"
-            }
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true
         },
         "npmlog": {
             "version": "4.1.2",
@@ -4178,16 +4331,6 @@
                 }
             }
         },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true,
-            "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
-            }
-        },
         "object.pick": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -4230,13 +4373,12 @@
             "dev": true
         },
         "opn": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-            "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+            "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
             "dev": true,
             "requires": {
-                "object-assign": "^4.0.1",
-                "pinkie-promise": "^2.0.0"
+                "is-wsl": "^1.1.0"
             }
         },
         "orchestrator": {
@@ -4298,18 +4440,6 @@
                 "path-root": "^0.1.1"
             }
         },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
-            "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
-            }
-        },
         "parse-json": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -4344,15 +4474,21 @@
             }
         },
         "parseurl": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-            "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
             "dev": true
         },
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
             "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
             "dev": true
         },
         "path-exists": {
@@ -4465,12 +4601,6 @@
             "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
             "dev": true
         },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-            "dev": true
-        },
         "pretty-hrtime": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -4501,46 +4631,21 @@
             "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
             "dev": true
         },
-        "randomatic": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-            "integrity": "sha1-01SQAw6091eN4pLObfsEqRoSiSM=",
-            "dev": true,
-            "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-                    "dev": true
-                }
-            }
-        },
         "range-parser": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "dev": true
         },
         "raw-body": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-            "integrity": "sha1-GzJOzmtXBuFThVvBFIxlu39uoMM=",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+            "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
             "dev": true,
             "requires": {
-                "bytes": "3.0.0",
-                "http-errors": "1.6.3",
-                "iconv-lite": "0.4.23",
+                "bytes": "3.1.0",
+                "http-errors": "1.7.3",
+                "iconv-lite": "0.4.24",
                 "unpipe": "1.0.0"
             }
         },
@@ -4589,15 +4694,14 @@
             }
         },
         "readdirp": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-            "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+            "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "readable-stream": "^2.0.2",
-                "set-immediate-shim": "^1.0.1"
+                "graceful-fs": "^4.1.11",
+                "micromatch": "^3.1.10",
+                "readable-stream": "^2.0.2"
             }
         },
         "rechoir": {
@@ -4617,15 +4721,6 @@
             "requires": {
                 "indent-string": "^2.1.0",
                 "strip-indent": "^1.0.1"
-            }
-        },
-        "regex-cache": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
-            "dev": true,
-            "requires": {
-                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -4865,6 +4960,15 @@
             "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
             "dev": true
         },
+        "rxjs": {
+            "version": "5.5.12",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+            "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+            "dev": true,
+            "requires": {
+                "symbol-observable": "1.0.1"
+            }
+        },
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -4913,9 +5017,9 @@
                     }
                 },
                 "lodash": {
-                    "version": "4.17.10",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-                    "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
                     "dev": true
                 },
                 "yargs": {
@@ -4998,6 +5102,24 @@
                 "statuses": "~1.4.0"
             },
             "dependencies": {
+                "http-errors": {
+                    "version": "1.6.3",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+                    "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+                    "dev": true,
+                    "requires": {
+                        "depd": "~1.1.2",
+                        "inherits": "2.0.3",
+                        "setprototypeof": "1.1.0",
+                        "statuses": ">= 1.4.0 < 2"
+                    }
+                },
+                "setprototypeof": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+                    "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+                    "dev": true
+                },
                 "statuses": {
                     "version": "1.4.0",
                     "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -5025,6 +5147,32 @@
                 "http-errors": "~1.6.2",
                 "mime-types": "~2.1.17",
                 "parseurl": "~1.3.2"
+            },
+            "dependencies": {
+                "http-errors": {
+                    "version": "1.6.3",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+                    "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+                    "dev": true,
+                    "requires": {
+                        "depd": "~1.1.2",
+                        "inherits": "2.0.3",
+                        "setprototypeof": "1.1.0",
+                        "statuses": ">= 1.4.0 < 2"
+                    }
+                },
+                "setprototypeof": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+                    "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+                    "dev": true
+                },
+                "statuses": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+                    "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+                    "dev": true
+                }
             }
         },
         "serve-static": {
@@ -5051,16 +5199,10 @@
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
             "dev": true
         },
-        "set-immediate-shim": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-            "dev": true
-        },
         "set-value": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-            "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+            "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
             "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
@@ -5081,9 +5223,9 @@
             }
         },
         "setprototypeof": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-            "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
             "dev": true
         },
         "sigmund": {
@@ -5297,6 +5439,17 @@
                         "debug": "~3.1.0",
                         "isarray": "2.0.1"
                     }
+                },
+                "ws": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+                    "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+                    "dev": true,
+                    "requires": {
+                        "async-limiter": "~1.0.0",
+                        "safe-buffer": "~5.1.0",
+                        "ultron": "~1.1.0"
+                    }
                 }
             }
         },
@@ -5307,35 +5460,46 @@
             "dev": true
         },
         "socket.io-client": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
-            "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
+            "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
             "dev": true,
             "requires": {
                 "backo2": "1.0.2",
                 "base64-arraybuffer": "0.1.5",
                 "component-bind": "1.0.0",
                 "component-emitter": "1.2.1",
-                "debug": "~2.6.4",
-                "engine.io-client": "~3.1.0",
+                "debug": "~3.1.0",
+                "engine.io-client": "~3.3.1",
+                "has-binary2": "~1.0.2",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "object-component": "0.0.3",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "socket.io-parser": "~3.1.1",
+                "socket.io-parser": "~3.3.0",
                 "to-array": "0.1.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
             }
         },
         "socket.io-parser": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
-            "integrity": "sha1-7S2l7nnxCVUDbj2kE7/X8eTYbI4=",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+            "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
             "dev": true,
             "requires": {
                 "component-emitter": "1.2.1",
                 "debug": "~3.1.0",
-                "has-binary2": "~1.0.2",
                 "isarray": "2.0.1"
             },
             "dependencies": {
@@ -5558,14 +5722,20 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "symbol-observable": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+            "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+            "dev": true
+        },
         "tar": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+            "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
             "dev": true,
             "requires": {
                 "block-stream": "*",
-                "fstream": "^1.0.2",
+                "fstream": "^1.0.12",
                 "inherits": "2"
             }
         },
@@ -5651,6 +5821,12 @@
                     }
                 }
             }
+        },
+        "toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+            "dev": true
         },
         "tough-cookie": {
             "version": "2.3.4",
@@ -5744,38 +5920,15 @@
             "dev": true
         },
         "union-value": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+            "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
             "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "get-value": "^2.0.6",
                 "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                },
-                "set-value": {
-                    "version": "0.4.3",
-                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
-                    }
-                }
+                "set-value": "^2.0.1"
             }
         },
         "unique-stream": {
@@ -5849,6 +6002,12 @@
                     "dev": true
                 }
             }
+        },
+        "upath": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+            "dev": true
         },
         "urix": {
             "version": "0.1.0",
@@ -6078,14 +6237,12 @@
             "dev": true
         },
         "ws": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-            "integrity": "sha1-8c+E/i1ekB686U767OeF8YeiKPI=",
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+            "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
             "dev": true,
             "requires": {
-                "async-limiter": "~1.0.0",
-                "safe-buffer": "~5.1.0",
-                "ultron": "~1.1.0"
+                "async-limiter": "~1.0.0"
             }
         },
         "xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -26,14 +26,15 @@
         "url": "https://github.com/BlackrockDigital/startbootstrap-grayscale.git"
     },
     "dependencies": {
-        "bootstrap": "4.1.x",
+        "bootstrap": "^4.3.1",
         "font-awesome": "4.7.x",
         "hoek": "^5.0.3",
-        "jquery": "3.3.x",
-        "jquery.easing": "^1.4.1"
+        "jquery": "^3.4.1",
+        "jquery.easing": "^1.4.1",
+        "lodash": "^4.17.15"
     },
     "devDependencies": {
-        "browser-sync": "^2.24.6",
+        "browser-sync": "^2.26.7",
         "gulp": "^3.9.1",
         "gulp-clean-css": "3.9.4",
         "gulp-header": "2.0.5",


### PR DESCRIPTION
fixed 3 of 14 vulnerabilities in 5269 scanned packages
  4 vulnerabilities required manual review and could not be updated
  1 package update for 7 vulns involved breaking changes
  (use `npm audit fix --force` to install breaking changes; or do it by hand)